### PR TITLE
Change non-ASCII quotes in example-config.py

### DIFF
--- a/example-config.py
+++ b/example-config.py
@@ -12,7 +12,7 @@ from defaults import *
 
 # The root URL that WhileyWeb will be accessed through.
 # It MUST NOT end in a slash. If the script_name refers to the root of the URI,
-# it MUST be an empty string (not “/”).
+# it MUST be an empty string (not "/").
 # ROOT_URL = ""
 
 # The home directory for WhileyWeb.


### PR DESCRIPTION
Using the existing example.config.py as a base can cause some confusing issues, as Python will complain about non-ASCII characters. This should prevent some headaches for first-time setup when someone creates their config.py.