### PR TITLE
Add a prompt when a user leaves the page to prevent accidental loss.

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -14,6 +14,11 @@
         var redirect = "${REDIRECT}";
     </script>
     <script type="text/javascript" src="js/whileyweb.js"></script>
+    <script type="text/javascript">
+        window.onbeforeunload = function(){
+ 		return 'Are you sure you want to leave Whiley on the Web? Changes will not be saved.';
+	};
+    </script>
 </head>
 <body>
     <div id="container">


### PR DESCRIPTION
This adds a prompt when the browser attempts to navigate away from the page, informing the user that changes will be unsaved, and helping prevent accidental loss from people hitting backspace outside of the text box.

This fixes #16, although it could potentially be implemented in a cleaner fashion (e.g. make it not prompt if the user hasn't made any changes).