### PR TITLE
compatibility with python 3.5.0

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -185,9 +185,9 @@ def compile(code,verify,dir):
             }]
         # Continue
         if err == None:
-            return splitErrors(out)
+            return splitErrors(out.decode())
         else:
-            return splitErrors(err)
+            return splitErrors(err.decode())
     except Exception as ex:
         # error, so return that
         return "Compile Error: " + str(ex)
@@ -211,7 +211,7 @@ def run(dir):
         timer.cancel()
         # Check what happened
         if proc.returncode >= 0:
-            return out
+            return out.decode()
         else:
             return "Timeout: Your program ran for too long!"
     except Exception as ex:


### PR DESCRIPTION
This will avoid the `Compile Error: a bytes-like object is required, not 'str'` that I got with current python when trying to compile or run the standard HelloWorld example.